### PR TITLE
Vish0007 enable chronos logging 1

### DIFF
--- a/chronos/README.md
+++ b/chronos/README.md
@@ -11,3 +11,7 @@ Example:
 ```
 ./mk.sh 2.3.0-0.1.20141121000021 0.21.0-1.0.ubuntu1404
 ```
+Check chronos logs:
+````
+docker exec <chronos container id> /bin/bash -c "tailf /var/log/messages"
+```

--- a/chronos/bin/docker-entrypoint.sh
+++ b/chronos/bin/docker-entrypoint.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+#start syslog daemon to enable chronos logging
+#syslogd is already installed in the chronos image
+syslogd
+#start chronos
+#this is coming from CMD[] in docker file [overwritten while running the chronos image]
+"$@"

--- a/chronos/chronos-template
+++ b/chronos/chronos-template
@@ -1,7 +1,7 @@
 FROM mesosphere/mesos:MESOS_VERSION
 MAINTAINER Mesosphere <support@mesosphere.io>
 
-RUN apt-get update && apt-get -y install chronos=CHRONOS_VERSION curl
+RUN apt-get update && apt-get -y install chronos=CHRONOS_VERSION curl syslogd
 RUN rm -rf /etc/mesos
 RUN rm -rf /etc/chronos/conf
 

--- a/chronos/chronos-template
+++ b/chronos/chronos-template
@@ -7,4 +7,8 @@ RUN rm -rf /etc/chronos/conf
 
 EXPOSE 4400
 
+COPY bin/docker-entrypoint.sh /
+
+ENTRYPOINT ["/docker-entrypoint.sh"]
+
 CMD ["/usr/bin/chronos", "run_jar", "--http_port", "4400", "--zk_hosts",  "localhost:2181", "--master", "zk://localhost:2181"]


### PR DESCRIPTION
Chronos logging to syslogd is enabled.
user can view logs of chronos via syslog messages inside the container.
if needed the chronos container logging can be mouted to local disk (-v <local disk path:/var/log/messages).
